### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ This is necessary because of how `elm-package` works; it may change in the futur
 Here are the commands (with explanation) that you should run to get started:
 
 ```sh
-mkdir benchmarks                             # create a benchmarks directory
-cd benchmarks                                # go into that directory
-elm package install BrianHicks/elm-benchmark # get this project, including the browser runner
+mkdir benchmarks                       # create a benchmarks directory
+cd benchmarks                          # go into that directory
+elm install elm-explorations/benchmark # get this project, including the browser runner
 ```
 
 You'll also need to add your main source directory (probably `../` or `../src`) to the `source-directories` list in `benchmarks/elm-package.json`.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ Here are the commands (with explanation) that you should run to get started:
 
 ```sh
 mkdir benchmarks                       # create a benchmarks directory
-cd benchmarks                          # go into that directory
 elm install elm-explorations/benchmark # get this project, including the browser runner
 ```
 


### PR DESCRIPTION
Hi Brian,

this is a just minor update of installation instructions to match 0.19 process. Just to make it easier for new folks to get it up and running.

NOTE:
This doesn't include the change in example bookmark which is also no longer valid as HATM became default implementation of Array in 0.19