### PR TITLE
Update README and Makefile for elm 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,10 @@ install:
     fi
 
   - make node_modules
-  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 make elm-stuff
-  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 make tests/elm-stuff
-  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 make examples/elm-stuff
 
 script:
   - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 make check-formatting
   - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 make documentation.json
   - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 make test
-  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 make examples/ElmArrayExploration.elm.html
   - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 make examples/Example.elm.html
   - make flow

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,11 @@
 ELM_FILES = $(shell find src -name '*.elm' -or -name '*.js')
 NPM_BIN = $(shell npm bin)
-ELM = env PATH=${NPM_BIN}:${PATH} elm
+ELM = env PATH=${NPM_BIN}:"${PATH}" elm
 
 .PHONY: all
 all: documentation.json test examples/Example.elm.html flow
 
 # package management
-
-elm-stuff: elm-package.json node_modules
-	${ELM} package install --yes
-	touch -m $@
-
-%elm-stuff: elm-package.json node_modules
-	cd $(@D); ${ELM} package install --yes
-	touch -m $@
 
 node_modules: package.json
 	npm install
@@ -21,17 +13,19 @@ node_modules: package.json
 
 # Elm
 
-documentation.json: ${ELM_FILES} elm-package.json node_modules
-	${ELM} make --yes --warn --docs=$@
+documentation.json: ${ELM_FILES} elm.json node_modules
+	${ELM} make --docs=$@
 
 .PHONY: test
-test: tests/elm-stuff node_modules
-	${ELM} test
+test: node_modules
+	echo "Tests cannot be run due to kernal code" && exit 1
+	# ${ELM}-test
 
-examples/%.html: examples/% examples/elm-stuff ${ELM_FILES} node_modules
-	cd examples; ${ELM} make --warn --yes --output $(shell basename $@) $(shell basename $<)
+examples/%.html: examples/% ${ELM_FILES} node_modules
+	echo "examples cannot be run due to kernal code" && exit 1
+	# cd examples; ${ELM} make --output $(shell basename $@) $(shell basename $<)
 
-# CLI
+# JavaScript
 
 .PHONY: flow
 flow: node_modules
@@ -41,8 +35,8 @@ flow: node_modules
 
 .PHONY: check-formatting
 check-formatting: node_modules
-	${ELM} format --validate $(shell find src tests -name '*.elm' -not -path '*elm-stuff*')
-	${NPM_BIN}/prettier -l $(shell find src cli -name '*.js')
+	${ELM}-format --validate $(shell find src tests -name '*.elm' -not -path '*elm-stuff*')
+	${NPM_BIN}/prettier -l $(shell find src -name '*.js')
 
 # Meta
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elm Benchmark
 
-[![Build Status](https://travis-ci.org/BrianHicks/elm-benchmark.svg?branch=master)](https://travis-ci.org/BrianHicks/elm-benchmark)
+[![Build Status](https://travis-ci.org/elm-explorations/benchmark.svg?branch=master)](https://travis-ci.org/BrianHicks/elm-benchmark)
 
 Run microbenchmarks in Elm.
 
@@ -62,18 +62,19 @@ This code uses a few common functions:
 - `benchmark` to run benchmarks
 - `compare` to compare the results of two benchmarks
 
-For a more thorough overview, I've written an [introduction to elm-benchmark](https://www.brianthicks.com/post/2017/02/27/introducing-elm-benchmark/).
+For a more thorough overview, I wrote an [introduction to elm-benchmark](https://www.brianthicks.com/post/2017/02/27/introducing-elm-benchmark/).
+Please note that the article was written for a previous version so some details may have changed slightly.
 
 ### Installing
 
-You should keep your benchmarks separate from your code since you don't want the elm-benchmark code in your production artifacts.
-This is necessary because of how `elm-package` works; it may change in the future.
+You should keep your benchmarks separate from your code since you don't want the benchmark code in your production artifacts.
+This is necessary because of how `elm make` works; it may change in the future.
 Here are the commands (with explanation) that you should run to get started:
 
 ```sh
 mkdir benchmarks                             # create a benchmarks directory
 cd benchmarks                                # go into that directory
-elm package install BrianHicks/elm-benchmark # get this project, including the browser runner
+elm install elm-explorations/benchmark       # get this project, including the browser runner
 ```
 
 You'll also need to add your main source directory (probably `../` or `../src`) to the `source-directories` list in `benchmarks/elm-package.json`.
@@ -109,16 +110,16 @@ Some general principles:
 
 Goodness of fit is a measurement of how well our prediction fits the measurements we have collected.
 You want this to be as close to 100% as possible.
-In elm-benchmark:
+In benchmark:
 
 - 99% is great
 - 95% is okay
 - 90% is not great, consider closing other programs on your computer and re-running
 - 80% and below, the result has been highly affected by outliers.
   Please do not trust the results when goodness of fit is this low.
-  
-elm-benchmark will eventually incorporate this advice into the reporting interface.
-See [Issue #13](https://github.com/BrianHicks/elm-benchmark/issues/13).
+
+benchmark will eventually incorporate this advice into the reporting interface.
+See [Issue #4](https://github.com/elm-explorations/benchmark/issues/4).
 
 For more, see [Wikipedia: Goodness of Fit](https://en.wikipedia.org/wiki/Goodness_of_fit).
 
@@ -155,4 +156,4 @@ It sets a more even playing field for all the benchmarks, and gives us better da
 
 ## License
 
-elm-benchmark is licensed under a 3-Clause BSD License.
+benchmark is licensed under a 3-Clause BSD License.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "engines": {
     "node": ">=6"
   },
-  "main": "cli/elm-benchmark.js",
   "bin": {
     "elm-benchmark": "cli/bin/elm-benchmark"
   },
@@ -27,11 +26,12 @@
     "which": "^1.3.0"
   },
   "devDependencies": {
-    "elm": "^0.18.0",
-    "elm-format": "^0.7.0-exp",
-    "elm-test": "^0.18.12",
+    "elm": "^0.19.0-bugfix2",
+    "elm-format": "^0.8.1",
+    "elm-test": "^0.19.0-rev3",
     "flow": "^0.2.3",
     "flow-bin": "^0.62.0",
-    "prettier": "^1.9.2"
+    "prettier": "^1.9.2",
+    "request": "^2.88.0"
   }
 }

--- a/src/Elm/Kernel/Benchmark.js
+++ b/src/Elm/Kernel/Benchmark.js
@@ -19,13 +19,9 @@ var _Benchmark_sample = F2(function(n, fn) {
       }
     } catch (error) {
       if (error instanceof RangeError) {
-        callback(__Scheduler_fail(
-          __BL_StackOverflow
-        ));
+        callback(__Scheduler_fail(__BL_StackOverflow));
       } else {
-        callback(__Scheduler_fail(
-          __BL_UnknownError(error.message)
-        ));
+        callback(__Scheduler_fail(__BL_UnknownError(error.message)));
       }
       return;
     }


### PR DESCRIPTION
Hi, I noticed some parts of the README still reference `BrianHicks/elm-benchmark` so I went ahead and updated all these references to now point to `elm-explorations/benchmark`. I also updated things like `elm-package` to be consistent with elm 19.

I also had a go at updating the Makefile to work with elm 19, I made some progress here and formatting, docs and flow now all work. However, elm refuses to build the tests or the examples due to the presence of kernel code.

As neither neither tests nor examples are running the CI fails - https://travis-ci.com/harrysarson/benchmark/builds/93493214.