### PR TITLE
Fix import typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Here's a sample, benchmarking [`Array.Hamt`](http://package.elm-lang.org/package
 
 ```elm
 import Array
-import Arry.Hamt as Hamt
+import Array.Hamt as Hamt
 import Benchmark exposing (..)
 
 


### PR DESCRIPTION
It was being imported as `Arry.Hamt` instead of `Array.Hamt`.