### PR TITLE
Remove reference to Array.Hamt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ suite =
         [ -- nest as many descriptions as you like
           describe "slice"
             [ benchmark "from the beginning" <|
-                \_ -> Hamt.slice 50 100 sampleArray
+                \_ -> Array.slice 50 100 sampleArray
             , benchmark "from the end" <|
-                \_ -> Hamt.slice 0 50 sampleArray
+                \_ -> Array.slice 0 50 sampleArray
             ]
         ]
 ```


### PR DESCRIPTION
This reference survived eac3a33e0bdf47baee690ee0b5bc1f4e714a028c when it should have been changed to from `Hamt` to `Array`.